### PR TITLE
fix overflow hidden text on small bar and bar gap

### DIFF
--- a/provisioning/dashboards/panels.json
+++ b/provisioning/dashboards/panels.json
@@ -350,7 +350,7 @@
                 "name": "Value",
                 "type": "number",
                 "values": [
-                  3290
+                  3
                 ]
               }
             ],

--- a/src/components/Bar.tsx
+++ b/src/components/Bar.tsx
@@ -41,7 +41,6 @@ const getStyles = (color: string) => (theme: GrafanaTheme2) => {
       paddingRight: '5px',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
-      overflow: 'hidden',
     }),
   };
 };

--- a/src/components/BarGap.tsx
+++ b/src/components/BarGap.tsx
@@ -4,7 +4,7 @@ import tinycolor from 'tinycolor2';
 import { Icon, type IconName, useStyles2 } from '@grafana/ui';
 import { formatPercentage } from '../utils';
 import { useTooltipProps, BarGapTooltip } from './Tooltip';
-import { type DisplayValue } from '@grafana/data';
+import { GrafanaTheme2, type DisplayValue } from '@grafana/data';
 
 type Props = {
   from: DisplayValue;
@@ -48,7 +48,7 @@ function getIconName(from: number, to: number): IconName {
   return 'arrow-right';
 }
 
-const getStyles = (from: DisplayValue, to?: DisplayValue) => () => {
+const getStyles = (from: DisplayValue, to?: DisplayValue) => (theme: GrafanaTheme2) => {
   if (!to) {
     return {};
   }
@@ -79,6 +79,7 @@ const getStyles = (from: DisplayValue, to?: DisplayValue) => () => {
     percentage: css({
       display: 'flex',
       position: 'absolute',
+      color: theme.colors.text.maxContrast,
       width: `${toPercent * 100}%`,
       justifyContent: 'center',
       alignItems: 'center',

--- a/src/components/BarGap.tsx
+++ b/src/components/BarGap.tsx
@@ -28,7 +28,8 @@ export function BarGap(props: Props): ReactElement | null {
   }
 
   return (
-    <div {...tooltipProps} className={styles.barGap}>
+    <div {...tooltipProps} className={styles.container}>
+      <div className={styles.barGap} />
       <div className={styles.percentage}>
         <Icon name={icon} />
         {' ' + formatPercentage(drop)}
@@ -61,21 +62,26 @@ const getStyles = (from: DisplayValue, to?: DisplayValue) => () => {
   const bottomRight = 100 - bottomLeft;
 
   return {
-    barGap: css({
+    container: css({
+      position: 'relative',
       display: 'flex',
-      backgroundColor: color,
-      flexGrow: 1,
-      clipPath: `polygon(${topLeft}% 0%, ${topRight}% 0%, ${bottomRight}% 100%, ${bottomLeft}% 100%)`,
+      flexGrow: 2,
       width: '100%',
       alignItems: 'center',
       justifyContent: 'center',
     }),
+    barGap: css({
+      width: '100%',
+      height: '100%',
+      backgroundColor: color,
+      clipPath: `polygon(${topLeft}% 0%, ${topRight}% 0%, ${bottomRight}% 100%, ${bottomLeft}% 100%)`,
+    }),
     percentage: css({
       display: 'flex',
+      position: 'absolute',
       width: `${toPercent * 100}%`,
       justifyContent: 'center',
       alignItems: 'center',
-      textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
     }),
   };


### PR DESCRIPTION
Fix truncated number in bar and bar gap component when number is small.

Before:
![20240822_10h03m25s_screenshot](https://github.com/user-attachments/assets/53623d8d-c41e-4eea-8547-93c2bf26203c)
After:
![20240822_10h02m59s_screenshot](https://github.com/user-attachments/assets/08cd59c3-9196-4e32-8147-3c202426242b)

