### PR TITLE
Added option to show retention percentage instead of drop off percentage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "funnel-panel",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "funnel-panel",
-      "version": "1.1.2",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",

--- a/provisioning/dashboards/panels.json
+++ b/provisioning/dashboards/panels.json
@@ -547,7 +547,7 @@
           "refId": "A"
         }
       ],
-      "title": "Funnel - one query with full values",
+      "title": "Funnel - show retention rate",
       "transformations": [
         {
           "id": "rowsToFields",

--- a/provisioning/dashboards/panels.json
+++ b/provisioning/dashboards/panels.json
@@ -478,6 +478,83 @@
       ],
       "title": "Funnel - multiple queries",
       "type": "mckn-funnel-panel"
+    },
+    {
+      "datasource": {
+        "type": "marcusolsson-static-datasource",
+        "uid": "vHsj2qbVk"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 23,
+        "w": 11,
+        "x": 0,
+        "y": 54
+      },
+      "id": 9,
+      "options": {
+        "seriesCountSize": "sm",
+        "showRemainedPercentage": true,
+        "showSeriesCount": false,
+        "sorting": "descending",
+        "text": "Default value of text input option"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "marcusolsson-static-datasource",
+            "uid": "vHsj2qbVk"
+          },
+          "frame": {
+            "fields": [
+              {
+                "config": {},
+                "name": "Label",
+                "type": "string",
+                "values": [
+                  "Sent",
+                  "Viewed",
+                  "Clicked",
+                  "Add to cart",
+                  "Purchased"
+                ]
+              },
+              {
+                "config": {},
+                "name": "Value",
+                "type": "number",
+                "values": [
+                  52300,
+                  35679,
+                  15690,
+                  5596,
+                  3290
+                ]
+              }
+            ],
+            "meta": {},
+            "name": "Sent"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Funnel - one query with full values",
+      "transformations": [
+        {
+          "id": "rowsToFields",
+          "options": {}
+        }
+      ],
+      "type": "mckn-funnel-panel"
     }
   ],
   "refresh": "",

--- a/src/components/BarGap.tsx
+++ b/src/components/BarGap.tsx
@@ -10,11 +10,12 @@ type Props = {
   from: DisplayValue;
   to?: DisplayValue;
   textColor: string;
+  showRemainedPercentage: boolean;
   'data-testid'?: string;
 };
 
 export function BarGap(props: Props): ReactElement | null {
-  const { from, to, textColor } = props;
+  const { from, to, textColor, showRemainedPercentage } = props;
   const styles = useStyles2(getStyles(from, to, textColor));
 
   const toPercentage = to?.percent ?? 0;
@@ -22,7 +23,7 @@ export function BarGap(props: Props): ReactElement | null {
   const drop = (fromPercentage - toPercentage) / fromPercentage;
   const icon = getIconName(fromPercentage, toPercentage);
   const tooltipProps = useTooltipProps({
-    content: <BarGapTooltip drop={drop} fromLabel={from.title ?? ''} toLabel={to?.title} />,
+    content: <BarGapTooltip drop={drop} fromLabel={from.title ?? ''} toLabel={to?.title} showRemainedPercentage={showRemainedPercentage} />,
   });
 
   if (!Boolean(to)) {
@@ -34,7 +35,7 @@ export function BarGap(props: Props): ReactElement | null {
       <div className={styles.barGap} />
       <div className={styles.percentage}>
         <Icon name={icon} />
-        {' ' + formatPercentage(drop)}
+        {' ' + formatPercentage((showRemainedPercentage ?? true) ? 1 - drop : drop)}
       </div>
     </div>
   );

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -6,13 +6,15 @@ import { Bar } from './Bar';
 import { TooltipProvider } from './Tooltip';
 import { type DisplayValue } from '@grafana/data';
 import { getContrastText, getDisplayValueKey } from '../utils';
+import { type PanelOptions } from '../types';
 
 type Props = {
   values: DisplayValue[];
+  options: PanelOptions;
 };
 
 export function Chart(props: Props): ReactElement {
-  const { values } = props;
+  const { values, options } = props;
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const textColor = getContrastText(values, theme);
@@ -23,7 +25,7 @@ export function Chart(props: Props): ReactElement {
         {values.map((v, i) => (
           <Fragment key={getDisplayValueKey(v)}>
             <Bar value={v} textColor={textColor} data-testid={`bar-${i}`} />
-            <BarGap from={v} to={values[i + 1]} textColor={textColor} data-testid={`gap-${i}`} />
+            <BarGap from={v} to={values[i + 1]} textColor={textColor} showRemainedPercentage={options.showRemainedPercentage} data-testid={`gap-${i}`} />
           </Fragment>
         ))}
       </TooltipProvider>

--- a/src/components/Chart.tsx
+++ b/src/components/Chart.tsx
@@ -6,15 +6,14 @@ import { Bar } from './Bar';
 import { TooltipProvider } from './Tooltip';
 import { type DisplayValue } from '@grafana/data';
 import { getContrastText, getDisplayValueKey } from '../utils';
-import { type PanelOptions } from '../types';
 
 type Props = {
   values: DisplayValue[];
-  options: PanelOptions;
+  showRemainedPercentage: boolean;
 };
 
 export function Chart(props: Props): ReactElement {
-  const { values, options } = props;
+  const { values, showRemainedPercentage } = props;
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const textColor = getContrastText(values, theme);
@@ -25,7 +24,13 @@ export function Chart(props: Props): ReactElement {
         {values.map((v, i) => (
           <Fragment key={getDisplayValueKey(v)}>
             <Bar value={v} textColor={textColor} data-testid={`bar-${i}`} />
-            <BarGap from={v} to={values[i + 1]} textColor={textColor} showRemainedPercentage={options.showRemainedPercentage} data-testid={`gap-${i}`} />
+            <BarGap
+              from={v}
+              to={values[i + 1]}
+              textColor={textColor}
+              showRemainedPercentage={showRemainedPercentage}
+              data-testid={`gap-${i}`}
+            />
           </Fragment>
         ))}
       </TooltipProvider>

--- a/src/components/FunnelPanel.tsx
+++ b/src/components/FunnelPanel.tsx
@@ -41,7 +41,7 @@ export function FunnelPanel(props: PanelProps<PanelOptions>): ReactElement {
       return (
         <div className={styles.container}>
           <PureLabels values={values} />
-          <PureChart values={values} />
+          <PureChart values={values} options={options} />
           <PurePercentages values={values} />
         </div>
       );

--- a/src/components/FunnelPanel.tsx
+++ b/src/components/FunnelPanel.tsx
@@ -12,17 +12,21 @@ import { Nodata } from './Nodata';
 
 export function FunnelPanel(props: PanelProps<PanelOptions>): ReactElement {
   const { width, height, data, options, fieldConfig, replaceVariables, timeZone } = props;
+  const { showRemainedPercentage } = options;
+
   const theme = useTheme2();
   const styles = useStyles2(getStyles(width, height));
 
-  const { values, status } = useFunnelData({
-    fieldConfig,
-    replaceVariables,
-    theme,
-    data: data.series,
-    timeZone,
-  }, options);
-
+  const { values, status } = useFunnelData(
+    {
+      fieldConfig,
+      replaceVariables,
+      theme,
+      data: data.series,
+      timeZone,
+    },
+    options
+  );
 
   switch (status) {
     case FunnelDataResultStatus.nodata:
@@ -41,7 +45,7 @@ export function FunnelPanel(props: PanelProps<PanelOptions>): ReactElement {
       return (
         <div className={styles.container}>
           <PureLabels values={values} />
-          <PureChart values={values} options={options} />
+          <PureChart values={values} showRemainedPercentage={showRemainedPercentage} />
           <PurePercentages values={values} />
         </div>
       );

--- a/src/components/Tooltip/BarGapTooltip.tsx
+++ b/src/components/Tooltip/BarGapTooltip.tsx
@@ -5,15 +5,19 @@ type Props = {
   drop: number;
   fromLabel: string;
   toLabel?: string;
+  showRemainedPercentage: boolean;
 };
 
 export function BarGapTooltip(props: Props): ReactElement {
-  const { drop, fromLabel, toLabel } = props;
+  const { drop, fromLabel, toLabel, showRemainedPercentage } = props;
 
   return (
     <div>
       <div>
-        {formatPercentage(drop)} drop from &quot;{fromLabel}&quot; to &quot;{toLabel}&quot;
+        {(showRemainedPercentage ?? true)
+          ? `${formatPercentage(1 - drop)} retained from "${fromLabel}" to "${toLabel}"`
+          : `${formatPercentage(drop)} drop from "${fromLabel}" to "${toLabel}"`
+        }
       </div>
     </div>
   );

--- a/src/module.ts
+++ b/src/module.ts
@@ -53,6 +53,6 @@ export const plugin = new PanelPlugin<PanelOptions>(FunnelPanel)
       name: 'Show retention rate',
       category: ['Funnel'],
       description: 'Show retention rate instead of drop-off rate in gap labels and tooltips',
-      defaultValue: true,
+      defaultValue: false,
     });
   });

--- a/src/module.ts
+++ b/src/module.ts
@@ -47,4 +47,12 @@ export const plugin = new PanelPlugin<PanelOptions>(FunnelPanel)
       },
       defaultValue: Sorting.descending,
     });
+
+    builder.addBooleanSwitch({
+      path: 'showRemainedPercentage',
+      name: 'Show retention rate',
+      category: ['Funnel'],
+      description: 'Show retention rate instead of drop-off rate in gap labels and tooltips',
+      defaultValue: true,
+    });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,5 @@ export enum Sorting {
 }
 export interface PanelOptions {
   sorting: Sorting;
+  showRemainedPercentage: boolean;
 }


### PR DESCRIPTION
Adds a panel setting to show retention rates instead of drop-off rates in funnel gaps and tooltips.