### PR TITLE
Remove fixed flexBasis to improve funnel space utilization

### DIFF
--- a/src/components/Labels.tsx
+++ b/src/components/Labels.tsx
@@ -28,7 +28,6 @@ export const PureLabels = React.memo(Labels);
 const getStyles = () => {
   return {
     container: css({
-      flexBasis: '120px',
       display: 'flex',
       flexDirection: 'column',
       paddingRight: '10px',

--- a/src/components/Percentages.tsx
+++ b/src/components/Percentages.tsx
@@ -28,7 +28,6 @@ export const PurePercentages = React.memo(Percentages);
 const getStyles = () => {
   return {
     container: css({
-      flexBasis: '120px',
       display: 'flex',
       flexDirection: 'column',
       paddingLeft: '10px',


### PR DESCRIPTION
## What does this PR do?

This PR removes the fixed `flexBasis: '120px'` property from 2 component files in the funnel plugin.

## Why?

The fixed flexBasis was constraining the funnel visualization to a minimum width of 120px, preventing it from utilizing the full available space in the panel. By removing this constraint, the funnel can now expand and make better use of the available panel space.

## Changes

- Removed `flexBasis: '120px'` from 2 funnel component files
- Funnel now uses available panel space more efficiently

### Before vs After for short funnels

<img width="1148" height="979" alt="before-after-short" src="https://github.com/user-attachments/assets/0b95f7e1-f61d-44b6-b119-d7019d70c1e5" />


### Before vs After for long funnels

<img width="1069" height="616" alt="before-after-long" src="https://github.com/user-attachments/assets/c2d98b57-a411-43fc-bb6c-6aa781f525fc" />

