### PR TITLE
Fix release pipeline failing plugin validation

### DIFF
--- a/src/loadResources.ts
+++ b/src/loadResources.ts
@@ -1,16 +1,13 @@
-import { LANGUAGES, type ResourceLoader, type Resources } from '@grafana/i18n';
+import { type ResourceLoader, type Resources } from '@grafana/i18n';
 import pluginJson from 'plugin.json';
 
-const pluginLanguageCodes = Array.isArray((pluginJson as any).languages)
-  ? new Set<string>((pluginJson as any).languages)
-  : new Set<string>();
-
-const resources = LANGUAGES.filter((lang) => pluginLanguageCodes.has(lang.code)).reduce<
-  Record<string, () => Promise<{ default: Resources }>>
->((acc, lang) => {
-  acc[lang.code] = async () => await import(`./locales/${lang.code}/${pluginJson.id}.json`);
-  return acc;
-}, {});
+const resources: Record<string, () => Promise<{ default: Resources }>> = {
+  'en-US': () => import('./locales/en-US/mckn-funnel-panel.json'),
+  'sv-SE': () => import('./locales/sv-SE/mckn-funnel-panel.json'),
+  'es-ES': () => import('./locales/es-ES/mckn-funnel-panel.json'),
+  'pt-BR': () => import('./locales/pt-BR/mckn-funnel-panel.json'),
+  'fr-FR': () => import('./locales/fr-FR/mckn-funnel-panel.json'),
+};
 
 export const loadResources: ResourceLoader = async (resolvedLanguage: string) => {
   try {


### PR DESCRIPTION
## Summary

Fixes the release workflow failure ([run](https://github.com/mckn/mckn-funnel-panel/actions/runs/25542154527/job/74970200756#step:3:301)) where the Grafana plugin validator rejected the build with:

> The provided javascript/typescript source code does not match your plugin archive assets.
> `./locales/ lazy ^\.\/.*\/.*\.json$ namespace object`

The dynamic template-string `import()` in `loadResources.ts` caused webpack to generate a virtual "lazy context module" in the source map that the validator couldn't match to any real source file. Replacing it with explicit static imports per language eliminates the virtual entry while preserving the same locale loading behavior.

## Test plan
- [x] `npm run build` succeeds, locale chunks still generated
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] Source map no longer contains the `lazy namespace object` entry
- [ ] CI release workflow passes plugin validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)